### PR TITLE
Add 0.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,3 +60,6 @@ extra:
   recipe-maintainers:
     - PhilipVinc
     - hbq1
+  skip-lints:
+    - missing_license_url
+    - missing_doc_source_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,19 @@ test:
 about:
   home: https://github.com/deepmind/chex
   summary: 'Chex: Testing made fun, in JAX!'
+  description: |
+    Chex is a library of utilities for helping to write reliable JAX code.
+
+    This includes utils to help:
+
+    - Instrument your code (e.g. assertions)
+    - Debug (e.g. transforming pmaps in vmaps within a context manager).
+    - Test JAX code across many variants (e.g. jitted vs non-jitted).
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  dev_url: https://github.com/deepmind/chex
+  doc_url: https://chex.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  # ppc64le, s390x and win are all unsupported by jax/jaxlib
   skip: true  # [ppc64le or s390x or win or py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,17 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  skip: true   #[py<37]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - absl-py >=0.9.0
     - dm-tree >=0.1.5
     - jax >=0.1.55

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true   #[py<37]
+  skip: true  # [ppc64le or s390x or win or py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - dm-tree >=0.1.5
     - jax >=0.1.55
     - jaxlib >=0.1.37
-    - numpy >=1.18.0
+    - numpy >=1.21,<2  # [py>=310 or (osx and arm64)]
+    - numpy >=1.20,<2  # [py<310 and not (osx and arm64)]
     - toolz >=0.9.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true   #[py<37]
 
 requirements:


### PR DESCRIPTION
# Chex 0.1.5
upstream: https://github.com/deepmind/chex/tree/v0.1.5
jira: https://anaconda.atlassian.net/browse/PKG-813
`setup.py`: https://github.com/deepmind/chex/blob/v0.1.5/setup.py#L61
`requirements.txt`: https://github.com/deepmind/chex/blob/v0.1.5/requirements/requirements.txt
`license`:  https://github.com/deepmind/chex/blob/v0.1.5/LICENSE

# Changes
- Forked from CF
- Update about section
- Remove noarch and add python dependencies
- Update numpy pinnings based on CBC and what's available in defaults