### PR TITLE
chex 0.1.89

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/dm-tree-feedstock/pr4/ded7d40
+  - https://staging.continuum.io/prefect/fs/dm-tree-feedstock/pr4/1d56963

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/dm-tree-feedstock/pr4/ded7d40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/dm-tree-feedstock/pr4/1d56963

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "chex" %}
-{% set version = "0.1.5" %}
+{% set version = "0.1.89" %}
 
 
 package:
@@ -8,13 +8,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/chex-{{ version }}.tar.gz
-  sha256: 686858320f8f220c82a6c7eeb54dcdcaa4f3d7f66690dacd13a24baa1ee8299e
+  sha256: 78f856e6a0a8459edfcbb402c2c044d2b8102eac4b633838cbdfdcdb09c6c8e0
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  # ppc64le, s390x and win are all unsupported by jax/jaxlib
-  skip: true  # [ppc64le or s390x or win or py<37]
+  # Matches jaxlib-feedstock's compatibility
+  skip: true  # [s390x or py<39]
 
 requirements:
   host:
@@ -26,19 +26,25 @@ requirements:
     - python
     - absl-py >=0.9.0
     - dm-tree >=0.1.5
-    - jax >=0.1.55
-    - jaxlib >=0.1.37
-    - numpy >=1.21,<2  # [py>=310 or (osx and arm64)]
-    - numpy >=1.20,<2  # [py<310 and not (osx and arm64)]
+    - jax >=0.4.27
+    - numpy >=1.24.1
     - toolz >=0.9.0
+    - typing_extensions >=4.2.0
+    - jaxlib >=0.4.27
+    - setuptools  # [py>=312]
 
 test:
   imports:
     - chex
-  commands:
-    - pip check
+  source_files:
+    - chex
   requires:
     - pip
+    - cloudpickle >=3,<3.2
+    - pytest
+  commands:
+    - pip check
+    - cd chex && pytest . -k "not fake_set_n_cpu_devices_test"
 
 about:
   home: https://github.com/deepmind/chex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,9 @@ test:
     - pytest
   commands:
     - pip check
-    - cd chex && pytest . -k "not fake_set_n_cpu_devices_test"
+    - cd chex && pytest . -k "not fake_set_n_cpu_devices_test"  # [not win]
+    # test_docstring_example fails with  AssertionError: Tree contains non-finite value: nan.
+    - cd chex && pytest . -k "not (fake_set_n_cpu_devices_test or test_docstring_example)"  # [win]
 
 about:
   home: https://github.com/deepmind/chex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   # Matches jaxlib-feedstock's compatibility
-  skip: true  # [s390x or py<39]
+  skip: true  # [s390x or py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   # Matches jaxlib-feedstock's compatibility
   skip: true  # [s390x or py<310]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "chex" %}
 {% set version = "0.1.89" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7412](https://anaconda.atlassian.net/browse/PKG-7412) 
- [Upstream repository](https://github.com/google-deepmind/chex/tree/v0.1.89)
- Requirements:
  - https://github.com/google-deepmind/chex/blob/v0.1.89/setup.py
  - https://github.com/google-deepmind/chex/blob/v0.1.89/requirements/requirements.txt
  - https://github.com/google-deepmind/chex/blob/v0.1.89/requirements/requirements-test.txt

### Explanation of changes:

- Skip py<310 to match jaxlib-feedstock's compatibility
- Update runtime dependencies
- Add source_files with the chex folder
- Add a test suite.

### Notes:

-

[PKG-7412]: https://anaconda.atlassian.net/browse/PKG-7412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ